### PR TITLE
Gexf support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@
 
 # Ada Library Information
 *.ali
+
+# Output files
+*.png
+*.gexf
+*.dot

--- a/tools/plot_graph.py
+++ b/tools/plot_graph.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Dict, List, Set
 
 import pygraphviz as pgv  # type: ignore
+import networkx as nx # type: ignore
 import yaml
 
 
@@ -77,6 +78,10 @@ def main() -> None:
     verify_graph(graph, state_nodes, data_nodes, channel_nodes)
 
     basename = Path(args.file).name.rsplit('.')[0]
+
+    G = nx.nx_agraph.from_agraph(graph)
+    nx.write_gexf(G, basename + '.gexf')
+
     graph.write(basename + '.dot')
     graph.layout('dot')
     graph.draw(basename + '.png')


### PR DESCRIPTION
Export graph also in [GEXF format](https://gephi.org/gexf/format/), an XML-based graph format I plan to use for importing graphs in my [graph layouter](https://github.com/senier/ContextStateChart).